### PR TITLE
Fix missing documentation

### DIFF
--- a/Sources/Formworks/Design System/FormSpec.swift
+++ b/Sources/Formworks/Design System/FormSpec.swift
@@ -7,9 +7,10 @@
 
 import UIKit
 
-/// This enum is used to specify all the numerical values used to
-/// create the visual of the CollectionView, such as the cell size,
-/// group size.
+/**This enum is used to specify all the numerical values used to
+ create the visual of the CollectionView, such as the cell size,
+ group size.
+ */
 enum FormSpec {
     // -MARK: UICollectionViewCompositionalLayout
     // Item layout

--- a/Sources/Formworks/Design System/FormSpec.swift
+++ b/Sources/Formworks/Design System/FormSpec.swift
@@ -12,15 +12,15 @@ import UIKit
 /// group size.
 enum FormSpec {
     // -MARK: UICollectionViewCompositionalLayout
-    /// Item layout
+    // Item layout
     static let itemFractionalWidth: CGFloat = 1
     static let itemFractionalHeight: CGFloat = 1
 
-    /// Group layout
+    // Group layout
     static let groupFractionalWidth: CGFloat = 1
     static let groupFractionalHeight: CGFloat = 0.2
     
-    /// Group spacing
+    // Group spacing
     static let groupSpacingTop: CGFloat = 16
     static let groupSpacingLeading: CGFloat = 16
     static let groupSpacingBottom: CGFloat = 16
@@ -29,9 +29,9 @@ enum FormSpec {
     /// This enum is used to configure specific visual aspects of
     /// the CollectionViewCell,  such as adding corner radius.
     enum Cell {
-        /// Cell corner radius
+        // Cell corner radius
         static let cornerRadius: CGFloat = 0.05
-        /// Cell shadow
+        // Cell shadow
         static let cellShadowBlur: CGFloat = 10
         static let cellShadowOffSetY: CGFloat = 4
         static let cellShadowOffSetX: CGFloat = 2

--- a/Sources/Formworks/FWForm/FWFormViewController.swift
+++ b/Sources/Formworks/FWForm/FWFormViewController.swift
@@ -7,8 +7,10 @@
 
 import UIKit
 
+/// Representation of a form. It displays each component as a cell of a `UICollectionView`.
 public final class FWFormViewController: UIViewController {
     // - MARK: Properties
+    /// The form containing components as cells.
     private lazy var formCollectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: setUpCollectionViewLayout())
         collectionView.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/Formworks/FWForm/FWFormViewController.swift
+++ b/Sources/Formworks/FWForm/FWFormViewController.swift
@@ -42,10 +42,12 @@ public final class FWFormViewController: UIViewController {
         super.viewDidLoad()
         setUpCollectionViewConstraints()
     }
-    
-    /// This function will set up the layout of the CollectionView. It first configure
-    /// the item size that will be present on a group. And then configure
-    /// the group size so it specifies the portion of the screen that will occupy
+
+    /**
+    This function will set up the layout of the CollectionView. It first configure
+    the item size that will be present on a group. And then configure
+    the group size so it specifies the portion of the screen that will occupy
+     */
     @available(iOS 13.0, *)
     private func setUpCollectionViewLayout() -> UICollectionViewCompositionalLayout {
         

--- a/Sources/Formworks/FWForm/FWFormViewControllerCell.swift
+++ b/Sources/Formworks/FWForm/FWFormViewControllerCell.swift
@@ -6,7 +6,11 @@
 //
 
 import UIKit
-
+/**
+ Representation of a component. It should **only** be
+ instantiated as part of `UICollectionView` inside a
+ `FWFormViewController`.
+ */
 final class FWFormViewControllerCell: UICollectionViewCell {
     
     static var identifier: String {
@@ -22,13 +26,13 @@ final class FWFormViewControllerCell: UICollectionViewCell {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    /// Use this function to make all needed visual set up for the cell
+    /// Use this function to make all needed visual set up for the cell.
     private func setUpContentView() {
-        /// Add corner radius to the cell
+        // Add corner radius to the cell
         contentView.backgroundColor = .fwComponentBackground
         contentView.layer.cornerRadius = contentView.frame.height * FormSpec.Cell.cornerRadius
         contentView.clipsToBounds = true
-        /// Add shadow drop to the cell
+        // Add shadow drop to the cell
         contentView.layer.shadowColor = UIColor.fwComponentShadow.cgColor
         contentView.layer.shadowOffset = CGSize(width: FormSpec.Cell.cellShadowOffSetX,
                                                 height: FormSpec.Cell.cellShadowOffSetY)

--- a/Sources/Formworks/Property Wrappers/ManualLayout.swift
+++ b/Sources/Formworks/Property Wrappers/ManualLayout.swift
@@ -8,8 +8,8 @@
 import UIKit
 
 /// Property wrapper used to make it easier to instantiate a `UIView` or
-/// its subclasses ready for Auto layout. **You should only use this property wrapper if you only
-/// need the object to be initialized with the following init:** `init(frame: .zero)`.
+/// its subclasses ready for Auto layout. **You should only use this property wrapper if you only**
+/// **need the object to be initialized with the following init:** `init(frame: .zero)`.
 @propertyWrapper final class ManualLayout<View: UIView> {
     /// A lazily instantiated `UIView` or `UIView` subclass with the
     /// `translatesAutoresizingMaskIntoConstraints` property set


### PR DESCRIPTION
## Motivation
Closes #38
## Modifications
* Added the missing documentation while not documenting certain variables as their name already describe
what they are and do. I've discussed this concept of only documenting what isn't self describing with @EdgSgroi. We should open an Issue or discuss here in this PR what kind of documentation we want.
* Fix documentation indentation to make use of `/** */` for 3 lines or longer and `///` for other cases.
## Result
Documentation has been added to`FWFormViewController` and `FWFormViewControllerCell`.

##  Checklist
 **This PR is**
* [x] In accordance with our coding principles.
* [x] Implementing tests wherever needed and possible.
* [x] Free of commented code.
* [x] Documented.
* [x] Closing an Issue or related to an Issue
* [x] Approved in the CI
