### PR TITLE
Fix the color system for first release

### DIFF
--- a/Sources/Formworks/Design System/FWStyleSpecification.swift
+++ b/Sources/Formworks/Design System/FWStyleSpecification.swift
@@ -20,6 +20,7 @@ public struct FWStyleSpecification: Codable {
     var componentInputBackground: UIColor = .fwComponentInputBackground
     var componentRequired: UIColor = .fwComponentRequired
     var componentCorrect: UIColor = .fwComponentCorrect
+    var componentPlaceholder: UIColor = .fwComponentPlaceholder
 }
 
 fileprivate struct FWStyleSpecificationDTO: Codable {
@@ -32,6 +33,7 @@ fileprivate struct FWStyleSpecificationDTO: Codable {
     let componentInputBackground: String?
     let componentRequired: String?
     let componentCorrect: String?
+    let componentPlaceholder: String?
 }
 
 extension FWStyleSpecification: Equatable {
@@ -46,6 +48,7 @@ extension FWStyleSpecification: Equatable {
         self.componentInputBackground = UIColor(hex: dto.componentInputBackground ?? "") ?? .fwComponentInputBackground
         self.componentRequired = UIColor(hex: dto.componentRequired ?? "") ?? .fwComponentRequired
         self.componentCorrect = UIColor(hex: dto.componentCorrect ?? "") ?? .fwComponentCorrect
+        self.componentPlaceholder = UIColor(hex: dto.componentPlaceholder ?? "") ?? .fwComponentPlaceholder
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -58,7 +61,8 @@ extension FWStyleSpecification: Equatable {
             componentInputText: self.componentInputText.toHex(true),
             componentInputBackground: self.componentInputBackground.toHex(true),
             componentRequired: self.componentRequired.toHex(true),
-            componentCorrect: self.componentCorrect.toHex(true)
+            componentCorrect: self.componentCorrect.toHex(true),
+            componentPlaceholder: self.componentPlaceholder.toHex(true)
         )
         try dto.encode(to: encoder)
     }
@@ -72,6 +76,7 @@ extension FWStyleSpecification: Equatable {
             lhs.componentInputText == rhs.componentInputText &&
             lhs.componentInputBackground == rhs.componentInputBackground &&
             lhs.componentRequired == rhs.componentRequired &&
-            lhs.componentCorrect == rhs.componentCorrect
+            lhs.componentCorrect == rhs.componentCorrect &&
+            lhs.componentPlaceholder == rhs.componentPlaceholder
     }
 }

--- a/Sources/Formworks/Extensions/UIColor+Extension.swift
+++ b/Sources/Formworks/Extensions/UIColor+Extension.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 extension UIColor {
-	static var style: FWStyle = .light
+    static var style: FWStyle = .light
 
     /// Creates a color object from a hex string value
     /// - Parameter hex: String Hex value. Formatted in #FFFFFF
@@ -88,6 +88,7 @@ extension UIColor {
 							   alpha: 1.0)
 			case .custom(let specification):
 				return specification.accent
+                
 		}
 	}
 	
@@ -227,4 +228,22 @@ extension UIColor {
 				return specification.componentCorrect
 		}
 	}
+    
+    class var fwComponentPlaceholder: UIColor {
+        switch self.style {
+        case .light:
+            return UIColor(red: 138.0/255.0,
+                           green: 138.0/255.0,
+                           blue: 138.0/255.0,
+                           alpha: 1.0)
+        case .dark:
+            return UIColor(red: 152.0/255.0,
+                           green: 152.0/255.0,
+                           blue: 152.0/255.0,
+                           alpha: 1.0)
+        case .custom(let specification):
+            return specification.componentPlaceholder
+        }
+        
+    }
 }

--- a/Sources/Formworks/FWComponents/FWFields/FWLabel.swift
+++ b/Sources/Formworks/FWComponents/FWFields/FWLabel.swift
@@ -56,6 +56,7 @@ final class FWLabel: UILabel {
 
     private func styleTitle() {
         font = UIFont.preferredFont(forTextStyle: .title3).bold().rounded()
+        textColor = .fwComponentTitle
         adjustsFontSizeToFitWidth = true
         minimumScaleFactor = 0.75
         numberOfLines = 3
@@ -63,6 +64,7 @@ final class FWLabel: UILabel {
 
     private func styleDescription() {
         font = UIFont.preferredFont(forTextStyle: .subheadline).rounded()
+        textColor = .fwComponentDescription
         numberOfLines = 0
     }
 

--- a/Sources/Formworks/FWComponents/FWFields/FWTextField.swift
+++ b/Sources/Formworks/FWComponents/FWFields/FWTextField.swift
@@ -21,6 +21,8 @@ final class FWTextField: UITextField {
 
     private func style() {
         backgroundColor = .fwComponentInputBackground
+        tintColor = .fwComponentInputText
+        textColor = .fwComponentInputText
         borderStyle = .roundedRect
         autocapitalizationType = .none
     }

--- a/Sources/Formworks/FWComponents/FWTextComponents/FWTextComponentView.swift
+++ b/Sources/Formworks/FWComponents/FWTextComponents/FWTextComponentView.swift
@@ -19,7 +19,7 @@ final class FWTextComponentView: UITableViewCell, FWComponentCell {
                 self.titleLabel.text = viewModel.title
                 self.descriptionLabel.text = viewModel.description
                 self.validatorLabel.text = ""
-                self.textField.placeholder = viewModel.placeholder
+                self.textField.attributedPlaceholder = NSAttributedString(string: viewModel.placeholder, attributes: [NSAttributedString.Key.foregroundColor: UIColor.fwComponentPlaceholder])
             }
         }
     }


### PR DESCRIPTION
## Motivation
The color style for the framework was not working properly and didn't have the right colors.

## Modifications
Made changes in the View, Color Extension and Design Specification to make the color style work when passing a color through the JSON and make the light color scheme be default

## Result
Colors should work now for our first release.

##  Checklist
 **This PR is**
* [x] In accordance with our coding principles.
* [x] Implementing tests wherever needed and possible.
* [x] Free of commented code.
* [x] Documented.
* [x] Closing an Issue or related to an Issue
* [x] Approved in the CI
