### PR TITLE
Bugfix/keyboard height

### DIFF
--- a/Sources/Formworks/Design System/ComponentSpec.swift
+++ b/Sources/Formworks/Design System/ComponentSpec.swift
@@ -26,7 +26,7 @@ enum ComponentSpec {
     
     static let errorMessageLabelTopConstant: CGFloat = 10
     
-    static let keyboardDistanceFromTextField: CGFloat = 32
+    static let keyboardDistanceFromTextField: CGFloat = 24
     
     /// Used to spacificate the `SingleLine` component.
     enum SingleLine {

--- a/Sources/Formworks/FWComponents/FWFields/FWTextView.swift
+++ b/Sources/Formworks/FWComponents/FWFields/FWTextView.swift
@@ -24,5 +24,6 @@ final class FWTextView: UITextView {
         autocapitalizationType = .none
         font = UIFont.preferredFont(forTextStyle: .body).rounded()
         textColor = .fwComponentInputText
+        isScrollEnabled = false
     }
 }

--- a/Sources/Formworks/FWForm/FWFormViewController.swift
+++ b/Sources/Formworks/FWForm/FWFormViewController.swift
@@ -72,7 +72,7 @@ public final class FWFormViewController: UIViewController {
         let keyboardScreenEndFrame = keyboardValue.cgRectValue
         let keyboardViewEndFrame = view.convert(keyboardScreenEndFrame, from: view.window)
 		
-        formTableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: keyboardViewEndFrame.height - view.safeAreaInsets.bottom, right: 0)
+        formTableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: keyboardViewEndFrame.height - view.safeAreaInsets.bottom + ComponentSpec.keyboardDistanceFromTextField, right: 0)
         
         formTableView.scrollIndicatorInsets = formTableView.contentInset
         

--- a/Sources/Formworks/FWForm/FWFormViewController.swift
+++ b/Sources/Formworks/FWForm/FWFormViewController.swift
@@ -46,12 +46,12 @@ public final class FWFormViewController: UIViewController {
     public override func viewDidLoad() {
         super.viewDidLoad()
         NotificationCenter.default.addObserver(self,
-                                               selector: #selector(adjustForKeyboard),
+                                               selector: #selector(keyBoardWillHide),
                                                name: UIResponder.keyboardWillHideNotification,
                                                object: nil)
         NotificationCenter.default.addObserver(self,
-                                               selector: #selector(adjustForKeyboard),
-                                               name: UIResponder.keyboardWillChangeFrameNotification,
+                                               selector: #selector(keyboardWillShow),
+                                               name: UIResponder.keyboardWillShowNotification,
                                                object: nil)
         addKeyboardDismissal()
         setUpViewModel()
@@ -63,24 +63,27 @@ public final class FWFormViewController: UIViewController {
         NotificationCenter.default.removeObserver(self)
     }
     
-    
+    // MARK: @objc
     /// Method to make the keyboard adjust when a text field is selected
     /// - Parameter notification: This is the observer for the keyboard in the Notification Center
-    @objc private func adjustForKeyboard(notification: Notification) {
+    @objc private func keyboardWillShow(notification: Notification) {
         guard let keyboardValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
         
         let keyboardScreenEndFrame = keyboardValue.cgRectValue
-        let keyboardViewEndFrame = view.convert(keyboardScreenEndFrame, from: view.window)
-        
-        if notification.name == UIResponder.keyboardWillHideNotification {
-            formTableView.contentInset = .zero
-        } else {
-            formTableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: (keyboardViewEndFrame.height - view.safeAreaInsets.bottom) + ComponentSpec.keyboardDistanceFromTextField, right: 0)
-        }
+		
+		formTableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: keyboardScreenEndFrame.height, right: 0)
         
         formTableView.scrollIndicatorInsets = formTableView.contentInset
+		
+		formTableView.scrollRectToVisible(keyboardScreenEndFrame, animated: true)
     }
     
+	@objc private func keyBoardWillHide(notification: Notification) {
+		formTableView.contentInset = .zero
+		
+		formTableView.scrollIndicatorInsets = formTableView.contentInset
+	}
+	
     // MARK: ViewModel setup
     /// Sets up the  `FWFormViewModel`.
     private func setUpViewModel() {

--- a/Sources/Formworks/FWForm/FWFormViewController.swift
+++ b/Sources/Formworks/FWForm/FWFormViewController.swift
@@ -70,12 +70,13 @@ public final class FWFormViewController: UIViewController {
         guard let keyboardValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
         
         let keyboardScreenEndFrame = keyboardValue.cgRectValue
+        let keyboardViewEndFrame = view.convert(keyboardScreenEndFrame, from: view.window)
 		
-		formTableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: keyboardScreenEndFrame.height, right: 0)
+        formTableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: keyboardViewEndFrame.height - view.safeAreaInsets.bottom, right: 0)
         
         formTableView.scrollIndicatorInsets = formTableView.contentInset
+        
 		
-		formTableView.scrollRectToVisible(keyboardScreenEndFrame, animated: true)
     }
     
 	@objc private func keyBoardWillHide(notification: Notification) {


### PR DESCRIPTION
## Motivation
Keyboard animation and scroll was not working with TextView for some reason when it was supposed to. And Closes #107 

## Modifications
The TextView scroll was interfering in some way with the animation, probably related for it being a totally different view and messing with the observers. So I disabled the scroll from the TextView.

## Result
The keyboard now doesn't hover on top of the TextView field, but still there is a slight delay on it happening.

##  Checklist
 **This PR is**
* [x] In accordance with our coding principles.
* [x] Implementing tests wherever needed and possible.
* [x] Free of commented code.
* [x] Documented.
* [x] Closing an Issue or related to an Issue
* [x] Approved in the CI
