### PR TITLE
Fix README links and package number

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ describing all the components and characteristics of a form.
 ### Importing using Xcode
 1. In a Xcode project, click on "File"
 2. Click on "Swift Packages" and select "Add Package Dependency"
-3. Paste the web url for this repository: https://github.com/Galdineris/Formworks.git
+3. Paste the web url for this repository: https://github.com/MyFormworks/Formworks.git
 4. Set Rules to Branch on "master"
 
 After this, you can fetch the latest changes to the framework  by selecting "Update to Latest Package Versions" in step 2.
@@ -49,7 +49,7 @@ import PackageDescription
 let package = Package(
     ...
     dependencies: [
-        .package(url: "https://github.com/myformworks/Formworks.git", VERSION)
+        .package(url: "https://github.com/myformworks/Formworks.git", "1.0.0")
     ],
     ...
 )


### PR DESCRIPTION
## Motivation
Fix README wrong link to Formworks and missing package number

## Modifications
Correctly linked the project in the README
Added the missing package number

## Result
The README is now displaying the most up to date information

##  Checklist
 **This PR is**
* [x] In accordance with our coding principles.
* [x] Implementing tests wherever needed and possible.
* [x] Free of commented code.
* [x] Documented.
* [x] Closing an Issue or related to an Issue
* [x] Approved in the CI
